### PR TITLE
Edit Profile Pages Redesign

### DIFF
--- a/src/components/EditProfile.js
+++ b/src/components/EditProfile.js
@@ -2,20 +2,23 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import api from '../utils/api';
 import { validateUserProfile } from '../utils/validationUtils';
-import { sanitizePlainText } from '../utils/sanitizer'; 
+import { sanitizePlainText } from '../utils/sanitizer';
+import './EditProfile.css';
+
 
 const FormField = ({ label, id, name, type = 'text', value, onChange, error }) => (
-    <div>
-      <label htmlFor={id}>{label}</label>
-      <input
-          id={id}
-          name={name}
-          type={type}
-          value={value}
-          onChange={onChange}
-      />
-      {error && <span className="error">{error}</span>}
-    </div>
+  <div className="form-field">
+    <label className="form-label" htmlFor={id}>{label}</label>
+    <input
+      className="form-input"
+      id={id}
+      name={name}
+      type={type}
+      value={value}
+      onChange={onChange}
+    />
+    {error && <span className="form-error">{error}</span>}
+  </div>
 );
 
 const EditProfile = () => {
@@ -93,12 +96,8 @@ const EditProfile = () => {
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
-
-    // Sanitize the input value as it changes
     const sanitizedValue = sanitizePlainText(value);
     setUser(prevUser => ({ ...prevUser, [name]: sanitizedValue }));
-    // Clear error for the field being changed
-
     if (errors[name]) {
       setErrors(prevErrors => ({ ...prevErrors, [name]: undefined }));
     }
@@ -114,82 +113,98 @@ const EditProfile = () => {
   };
 
   if (isLoading) {
-    return <div className="loading">Loading...</div>;
+    return <div className="loading-container">Loading...</div>;
   }
 
   if (apiError) {
     return (
-        <div className="error-container">
-          <div className="error">{apiError}</div>
-          <button onClick={fetchUserData} className="retry-button">
-            Retry
-          </button>
-        </div>
+      <div className="error-container">
+        <div className="error-message">{apiError}</div>
+        <button onClick={fetchUserData} className="button button-retry">
+          Retry
+        </button>
+      </div>
     );
   }
 
   return (
-      <div className="edit-profile">
-        <h1>Edit Profile</h1>
-        <form onSubmit={handleSubmit}>
-          {isAdmin && (
-            <>
+    <div className="edit-profile-container">
+      <div className="decorative-lines"></div>
+      <div className="edit-profile-content">
+        <h1 className="page-title">Edit Profile</h1>
+        <form onSubmit={handleSubmit} className="profile-form">
+          <div className="form-row">
+            {isAdmin && (
               <FormField
-                label="Name:"
+                label="Name"
                 id="name"
                 name="name"
                 value={user.name}
                 onChange={handleInputChange}
                 error={errors.name}
               />
+            )}
+            <FormField
+              label="Username"
+              id="username"
+              name="username"
+              value={user.username}
+              onChange={handleInputChange}
+              error={errors.username}
+            />
+          </div>
+          <div className="form-row">
+            {isAdmin && (
               <FormField
-                label="Position:"
+                label="Position"
                 id="position"
                 name="position"
                 value={user.position}
                 onChange={handleInputChange}
                 error={errors.position}
               />
-            </>
-          )}
-          <FormField
-              label="Username:"
-              id="username"
-              name="username"
-              value={user.username}
-              onChange={handleInputChange}
-              error={errors.username}
-          />
-          <FormField
-              label="Email:"
+            )}
+            <FormField
+              label="Email"
               id="email"
               name="email"
               type="email"
               value={user.email}
               onChange={handleInputChange}
               error={errors.email}
-          />
-          <FormField
-              label="Old Password:"
+            />
+          </div>
+          <div className="password-section">
+            <FormField
+              label="Old Password"
               id="oldPassword"
               name="oldPassword"
               type="password"
               value={user.oldPassword}
               onChange={handleInputChange}
               error={errors.oldPassword}
-          />
-          <FormField
-              label="New Password:"
+            />
+            <FormField
+              label="New Password"
               id="newPassword"
               name="newPassword"
               type="password"
               value={user.newPassword}
               onChange={handleInputChange}
               error={errors.newPassword}
-          />
-          <button type="submit">Save Changes</button>
+            />
+          </div>
+          <div className="button-container">
+            <button type="button" onClick={() => navigate('/app')} className="button button-secondary">
+              Cancel
+            </button>
+            <button type="submit" className="button button-primary">
+              Save Changes
+            </button>
+          </div>
         </form>
       </div>
+    </div>
   );
 };
 

--- a/src/components/EditUserOrgProfile.css
+++ b/src/components/EditUserOrgProfile.css
@@ -62,6 +62,7 @@
   font-size: 14px;
   color: #000000;
   margin-bottom: 8px;
+  text-transform: capitalize;
 }
 
 .form-input {
@@ -82,14 +83,7 @@
   border-bottom-width: 2px;
 }
 
-/* Password Section */
-.password-section {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 40px;
-  width: 100%;
-}
-
+/* Button Styles */
 .button-container {
   display: flex;
   justify-content: flex-end;
@@ -126,6 +120,16 @@
   background-color: #7A8499;
 }
 
+.button-retry {
+  background-color: #0D3B66;
+  color: #FFFFFF;
+}
+
+.button-retry:hover {
+  background-color: #0A2E4F;
+}
+
+/* Loading and Error States */
 .loading-container {
   text-align: center;
   padding: 20px;
@@ -137,6 +141,7 @@
   padding: 16px;
   background-color: #FFE5E5;
   margin-bottom: 16px;
+  border-radius: 4px;
 }
 
 .error-message {
@@ -154,8 +159,7 @@
 }
 
 @media (max-width: 768px) {
-  .form-row,
-  .password-section {
+  .form-row {
     grid-template-columns: 1fr;
     gap: 24px;
   }

--- a/src/components/EditUserOrgProfile.js
+++ b/src/components/EditUserOrgProfile.js
@@ -1,12 +1,28 @@
-import React, {useEffect, useState} from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import api from '../utils/api';
+import './EditUserOrgProfile.css';
+
+const FormField = ({ label, id, name, type = 'text', value, onChange }) => (
+  <div className="form-field">
+    <label className="form-label" htmlFor={id}>
+      {label}
+    </label>
+    <input
+      className="form-input"
+      id={id}
+      name={name}
+      type={type}
+      value={value}
+      onChange={onChange}
+    />
+  </div>
+);
 
 const EditUserOrgProfile = () => {
-  const  { userId } = useParams();
+  const { userId } = useParams();
   const navigate = useNavigate();
 
-  // RAHHHHHHHHH
   const [formData, setFormData] = useState({
     username: '',
     email: '',
@@ -20,7 +36,7 @@ const EditUserOrgProfile = () => {
     const fetchUserData = async () => {
       try {
         const response = await api.get(`/api/user/profile/${userId}`);
-        console.log(response.data)
+        console.log(response.data);
         setFormData({
           username: response.data.username,
           email: response.data.email,
@@ -37,8 +53,8 @@ const EditUserOrgProfile = () => {
   }, [userId]);
 
   const handleChange = (e) => {
-    const {name, value} = e.target;
-    setFormData((prev) => ({...prev, [name]: value}));
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
   const handleSubmit = async (e) => {
@@ -52,38 +68,73 @@ const EditUserOrgProfile = () => {
   };
 
   if (isLoading) {
-    return <div className="loading">Loading...</div>;
+    return <div className="loading-container">Loading...</div>;
   }
 
   if (apiError) {
     return (
-        <div className="error-container">
-          <div className="error">{apiError}</div>
-          <button onClick={() => setApiError(null)} className="retry-button">
-            Retry
-          </button>
-        </div>
+      <div className="error-container">
+        <div className="error-message">{apiError}</div>
+        <button onClick={() => setApiError(null)} className="button button-retry">
+          Retry
+        </button>
+      </div>
     );
   }
 
   return (
-    <div className="edit-user-org-profile">
-      <h1>Edit User Organisation Profile</h1>
-      <form onSubmit={handleSubmit}>
-        {['username', 'email', 'name', 'position'].map((field) => (
-          <div key={field}>
-            <label htmlFor={field}>{field.replace(/([A-Z])/g, ' $1')}: </label>
-            <input
-              id={field}
-              name={field}
-              type="text"
-              value={formData[field]}
+    <div className="edit-profile-container">
+      <div className="decorative-lines"></div>
+      <div className="edit-profile-content">
+        <h1 className="page-title">Edit User Organisation Profile</h1>
+        <form onSubmit={handleSubmit} className="profile-form">
+          <div className="form-row">
+            <FormField
+              label="Name"
+              id="name"
+              name="name"
+              value={formData.name}
+              onChange={handleChange}
+            />
+            <FormField
+              label="Username"
+              id="username"
+              name="username"
+              value={formData.username}
               onChange={handleChange}
             />
           </div>
-        ))}
-        <button type="submit">Save Changes</button>
-      </form>
+          <div className="form-row">
+            <FormField
+              label="Position"
+              id="position"
+              name="position"
+              value={formData.position}
+              onChange={handleChange}
+            />
+            <FormField
+              label="Email"
+              id="email"
+              name="email"
+              type="email"
+              value={formData.email}
+              onChange={handleChange}
+            />
+          </div>
+          <div className="button-container">
+            <button
+              type="button"
+              onClick={() => navigate('/app')}
+              className="button button-secondary"
+            >
+              Cancel
+            </button>
+            <button type="submit" className="button button-primary">
+              Save Changes
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   );
 };

--- a/src/components/EditUserOrgProfile.js
+++ b/src/components/EditUserOrgProfile.js
@@ -6,6 +6,7 @@ const EditUserOrgProfile = () => {
   const  { userId } = useParams();
   const navigate = useNavigate();
 
+  // RAHHHHHHHHH
   const [formData, setFormData] = useState({
     username: '',
     email: '',

--- a/src/components/__tests__/EditProfile.test.js
+++ b/src/components/__tests__/EditProfile.test.js
@@ -139,29 +139,29 @@ describe('EditProfile Component', () => {
     });
   });
 
-describe('Password Fields', () => {
-  it('should handle password changes', async () => {
-    // Mock successful API call for fetching user data
-    api.get.mockResolvedValue({ data: mockUserData });
-
-    renderComponent();
-
-    // Wait for the Old Password input to appear after successful data fetching
-    await waitFor(() => {
-      expect(screen.getByLabelText('Old Password')).toBeInTheDocument();
+  describe('Password Fields', () => {
+    it('should handle password changes', async () => {
+      // Mock successful API call for fetching user data
+      api.get.mockResolvedValue({ data: mockUserData });
+  
+      renderComponent();
+  
+      // Wait for the Old Password input to appear after successful data fetching
+      await waitFor(() => {
+        expect(screen.getByLabelText('Old Password')).toBeInTheDocument();
+      });
+  
+      const oldPasswordInput = screen.getByLabelText('Old Password');
+      const newPasswordInput = screen.getByLabelText('New Password');
+  
+      fireEvent.change(oldPasswordInput, { target: { value: 'oldPassword123' } });
+      fireEvent.change(newPasswordInput, { target: { value: 'newPassword123' } });
+  
+      expect(oldPasswordInput.value).toBe('oldPassword123');
+      expect(newPasswordInput.value).toBe('newPassword123');
     });
-
-    const oldPasswordInput = screen.getByLabelText('Old Password');
-    const newPasswordInput = screen.getByLabelText('New Password');
-
-    fireEvent.change(oldPasswordInput, { target: { value: 'oldPassword123' } });
-    fireEvent.change(newPasswordInput, { target: { value: 'newPassword123' } });
-
-    expect(oldPasswordInput.value).toBe('oldPassword123');
-    expect(newPasswordInput.value).toBe('newPassword123');
   });
-});
-
+  
 
   describe('Navigation', () => {
     const mockNavigate = jest.fn();

--- a/src/components/__tests__/EditProfile.test.js
+++ b/src/components/__tests__/EditProfile.test.js
@@ -137,6 +137,35 @@ describe('EditProfile Component', () => {
         expect(screen.getByText('Update failed')).toBeInTheDocument();
       });
     });
+
+    it('should clear field-specific error when input changes', async () => {
+      // Set up initial error state
+      validateUserProfile.mockReturnValue({ username: 'Username is required' });
+      
+      renderComponent();
+      await waitFor(() => screen.getByLabelText('Username'));
+
+      // Trigger form submission to get error state
+      fireEvent.click(screen.getByText('Save Changes'));
+      
+      // Verify error is displayed
+      await waitFor(() => {
+        expect(screen.getByText('Username is required')).toBeInTheDocument();
+      });
+
+      // Change input to trigger error clearing
+      const usernameInput = screen.getByLabelText('Username');
+      fireEvent.change(usernameInput, { 
+        target: { name: 'username', value: 'newusername' } 
+      });
+
+      // Verify error is cleared
+      await waitFor(() => {
+        expect(screen.queryByText('Username is required')).not.toBeInTheDocument();
+      });
+    });
+
+    
   });
 
   describe('Password Fields', () => {


### PR DESCRIPTION
Hello gang, I am back with another pull request. I've made a new redesign to the Edit Profile pages. Specifically when editing one's own User Profile, and when an Organisation admin is about to edit another user's profile, take a look:


<img width="1164" alt="Screenshot 2024-11-05 at 19 25 40" src="https://github.com/user-attachments/assets/5cbcb8c0-8d86-4e1e-8a83-92846f03f18c">

<img width="1207" alt="Screenshot 2024-11-05 at 19 26 48" src="https://github.com/user-attachments/assets/0f2db253-2a12-4600-a2ec-2bde5b76cd50">

This Pull Request features tests that has been covered 100%, and hopefully no issues (I think, let's see what Sonarcloud thinks). So please do review it whence you get the chance